### PR TITLE
the problem exists when trying to get a reflection annotation from

### DIFF
--- a/lib/Notoj/Notoj.php
+++ b/lib/Notoj/Notoj.php
@@ -90,7 +90,7 @@ class Notoj
 
     public static function parseDocComment($content) {
         $id = sha1($content);
-        if (!empty(self::$cached[$id])) {
+        if (isset(self::$cached[$id])) {
             return self::$cached[$id];
         }
         $pzToken = new Tokenizer($content);


### PR DESCRIPTION
class, method or any that has not a @annotation() ... always is
parsing and canching is not being used because on the condition is
a !empty() condition, but for a comment without a valid annotation
like:

class x{
  /*\* some comment */
  function m() {}
}

--- on Notoj.php, line 93:

if (!empty(self::$cached[$id])) {
   return self::$cached[$id];
}

the annotation was parsed and stored on cache file correctly
but self::$cached[$id] value is really empty. So I ve solved changing it
!empty() by isset(), and it works, so it will not parse always.
