### PR TITLE
Fix error in PHP7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   include:

--- a/lib/Notoj/Tokenizer.php
+++ b/lib/Notoj/Tokenizer.php
@@ -197,7 +197,7 @@ class Tokenizer
                     }
 
                     if (strlen($data) == 0) {
-                        continue;
+                        continue 2;
                     }
 
                     $e--;


### PR DESCRIPTION
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?